### PR TITLE
Fix missing uploads directory

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -13,6 +13,7 @@ from gradio_client import Client, handle_file
 # ================= CONFIG =================
 
 UPLOAD_FOLDER = 'uploads'
+os.makedirs(UPLOAD_FOLDER, exist_ok=True)
 ALLOWED_EXTENSIONS = {'pdf'}
 IMAGES_DIR = Path("images")
 IMAGES_DIR.mkdir(exist_ok=True)


### PR DESCRIPTION
## Summary
- create uploads folder at startup

## Testing
- `python3 -m py_compile server.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_685c5f4c046c8327af3d8015e1d79af7